### PR TITLE
fix: make rounding to nearest decimal

### DIFF
--- a/src/pages/BeatmapEditor.tsx
+++ b/src/pages/BeatmapEditor.tsx
@@ -293,7 +293,7 @@ export default function BeatmapEditorPage() {
       return {
         uuid,
         songPos,
-        beat: beatDurationMs > 0 ? songPos / beatDurationMs : 0,
+        beat: beatDurationMs > 0 ? Math.round((songPos / beatDurationMs) * 100) / 100 : 0,
         label: '',
         lane,
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Beat values in exports are now rounded to two decimal places for improved consistency in exported data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gamewota/dashboard/pull/49)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->