### PR TITLE
Implement beatmap save, update, and approval workflow

### DIFF
--- a/src/components/BeatmapEditor/Controls.tsx
+++ b/src/components/BeatmapEditor/Controls.tsx
@@ -28,6 +28,9 @@ interface ControlsProps {
   onBpmChange: (bpm: number) => void
   onExport: () => void
   onImport: (event: ChangeEvent<HTMLInputElement>) => void
+  onSave?: () => void
+  isSaving?: boolean
+  canSave?: boolean
 }
 
 export function Controls({
@@ -51,6 +54,9 @@ export function Controls({
   onBpmChange,
   onExport,
   onImport,
+  onSave,
+  isSaving = false,
+  canSave = false,
 }: ControlsProps) {
   return (
     <div className="card bg-base-200 shadow-lg">
@@ -219,12 +225,29 @@ export function Controls({
                 onChange={onImport}
               />
             </label>
-            <button className="btn btn-sm btn-primary" onClick={onExport}>
+            <button className="btn btn-sm btn-outline" onClick={onExport}>
               <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
               </svg>
               Export
             </button>
+            {onSave && (
+              <button
+                className="btn btn-sm btn-primary"
+                onClick={onSave}
+                disabled={isSaving || !canSave}
+                title={canSave ? 'Save beatmap to server' : 'Select a difficulty to save'}
+              >
+                {isSaving ? (
+                  <span className="loading loading-spinner loading-xs" aria-label="Saving" role="status"></span>
+                ) : (
+                  <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                  </svg>
+                )}
+                {isSaving ? 'Saving…' : 'Save'}
+              </button>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/BeatmapEditor/Header.tsx
+++ b/src/components/BeatmapEditor/Header.tsx
@@ -1,15 +1,21 @@
 import { useNavigate } from 'react-router-dom'
 import type { Song as BeatmapSong } from '@gamewota/beatmap-editor'
-import type { Beatmap } from '../../lib/schemas/song'
+import type { Beatmap, Difficulty } from '../../lib/schemas/song'
 
 interface HeaderProps {
   isSpecificSongMode: boolean
   song: BeatmapSong
   availableSongs: BeatmapSong[]
   availableBeatmaps: Beatmap[]
+  difficulties: Difficulty[]
   selectedDifficulty: string
   onSongChange: (song: BeatmapSong) => void
   onSelectedDifficultyChange: (difficulty: string) => void
+  isReviewMode?: boolean
+  isApproving?: boolean
+  isSelectedApproved?: boolean
+  onApprove?: () => void
+  onReject?: () => void
 }
 
 export function Header({
@@ -17,18 +23,32 @@ export function Header({
   song,
   availableSongs,
   availableBeatmaps,
+  difficulties,
   selectedDifficulty,
   onSongChange,
   onSelectedDifficultyChange,
+  isReviewMode = false,
+  isApproving = false,
+  isSelectedApproved = false,
+  onApprove,
+  onReject,
 }: HeaderProps) {
+  // Which difficulties already have a saved beatmap on this song (for labeling).
+  const savedDifficulties = new Set(
+    availableBeatmaps.map((bm) => bm.difficulty_name.toLowerCase()),
+  )
   const navigate = useNavigate()
 
   return (
     <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
       <div>
-        <h1 className="text-3xl font-bold">Beatmap Editor</h1>
+        <h1 className="text-3xl font-bold">
+          {isReviewMode ? 'Beatmap Review' : 'Beatmap Editor'}
+        </h1>
         <p className="text-base-content/70 mt-1">
-          Create and edit beatmaps for rhythm game songs
+          {isReviewMode
+            ? 'Play the song with the chart, then approve or reject'
+            : 'Create and edit beatmaps for rhythm game songs'}
         </p>
       </div>
 
@@ -55,22 +75,73 @@ export function Header({
         <div className="flex items-center gap-2 flex-wrap">
           <span className="badge badge-lg badge-primary">{song.title}</span>
 
-          {availableBeatmaps.length > 0 && (
-            <div className="flex items-center gap-2">
-              <label htmlFor="difficulty-select" className="text-sm font-medium">Level:</label>
-              <select
-                id="difficulty-select"
-                className="select select-bordered select-sm"
-                value={selectedDifficulty}
-                onChange={(e) => onSelectedDifficultyChange(e.target.value)}
-              >
-                <option value="">Select difficulty...</option>
-                {availableBeatmaps.map((beatmap) => (
-                  <option key={beatmap.difficulty_name} value={beatmap.difficulty_name}>
-                    {beatmap.difficulty_name}
+          <div className="flex items-center gap-2">
+            <label htmlFor="difficulty-select" className="text-sm font-medium">Level:</label>
+            <select
+              id="difficulty-select"
+              className="select select-bordered select-sm"
+              value={selectedDifficulty}
+              onChange={(e) => onSelectedDifficultyChange(e.target.value)}
+            >
+              <option value="">Select difficulty...</option>
+              {difficulties
+                // In review mode only existing beatmaps are reviewable.
+                .filter((d) => !isReviewMode || savedDifficulties.has(d.name.toLowerCase()))
+                .map((difficulty) => (
+                  <option key={difficulty.id} value={difficulty.name}>
+                    {difficulty.name}
+                    {savedDifficulties.has(difficulty.name.toLowerCase()) ? '' : ' (new)'}
                   </option>
                 ))}
-              </select>
+            </select>
+          </div>
+
+          {isReviewMode && (
+            <div className="flex items-center gap-2">
+              {isSelectedApproved ? (
+                <>
+                  <span className="badge badge-success gap-1">
+                    <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                    </svg>
+                    Approved
+                  </span>
+                  <button
+                    className="btn btn-sm btn-outline btn-warning"
+                    onClick={onReject}
+                    disabled={isApproving || !selectedDifficulty}
+                    title="Remove approval (send back for review)"
+                  >
+                    {isApproving ? (
+                      <span className="loading loading-spinner loading-xs" aria-label="Submitting" role="status"></span>
+                    ) : (
+                      'Revoke approval'
+                    )}
+                  </button>
+                </>
+              ) : (
+                <>
+                  <button
+                    className="btn btn-sm btn-error"
+                    onClick={onReject}
+                    disabled={isApproving || !selectedDifficulty}
+                  >
+                    Reject
+                  </button>
+                  <button
+                    className="btn btn-sm btn-success"
+                    onClick={onApprove}
+                    disabled={isApproving || !selectedDifficulty}
+                    title="Approve this beatmap"
+                  >
+                    {isApproving ? (
+                      <span className="loading loading-spinner loading-xs" aria-label="Submitting" role="status"></span>
+                    ) : (
+                      'Approve'
+                    )}
+                  </button>
+                </>
+              )}
             </div>
           )}
 

--- a/src/components/SongDetailModal.tsx
+++ b/src/components/SongDetailModal.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom';
 import Modal from './Modal';
 import type { SongDetail } from '../lib/schemas/song';
 
@@ -10,6 +11,7 @@ interface SongDetailModalProps {
 }
 
 export function SongDetailModal({ isOpen, onClose, song, loading, error }: SongDetailModalProps) {
+  const navigate = useNavigate();
   return (
     <Modal
       isOpen={isOpen}
@@ -113,17 +115,37 @@ export function SongDetailModal({ isOpen, onClose, song, loading, error }: SongD
                 {song.beatmaps.map((beatmap) => (
                   <div key={beatmap.difficulty_name} className="bg-base-200 p-3 rounded-lg flex justify-between items-center">
                     <div>
-                      <span className="badge badge-primary">{beatmap.difficulty_name}</span>
+                      <div className="flex items-center gap-2">
+                        <span className="badge badge-primary">{beatmap.difficulty_name}</span>
+                        <span className={`badge ${beatmap.is_approved ? 'badge-success' : 'badge-warning'}`}>
+                          {beatmap.is_approved ? 'Approved' : 'Pending'}
+                        </span>
+                      </div>
                       <p className="font-mono text-xs mt-1 text-base-content/50">{beatmap.beatmap_asset_key}</p>
                     </div>
-                    <a 
-                      href={beatmap.beatmap_asset_url} 
-                      target="_blank" 
-                      rel="noopener noreferrer"
-                      className="btn btn-sm btn-outline"
-                    >
-                      View
-                    </a>
+                    <div className="flex items-center gap-2">
+                      {beatmap.beatmap_asset_url && (
+                        <a
+                          href={beatmap.beatmap_asset_url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="btn btn-sm btn-outline"
+                        >
+                          View
+                        </a>
+                      )}
+                      <button
+                        className="btn btn-sm btn-primary"
+                        onClick={() => {
+                          navigate(
+                            `/dashboard/${song.song_id}/beatmap-editor?mode=review&difficulty=${encodeURIComponent(beatmap.difficulty_name)}`,
+                          );
+                          onClose();
+                        }}
+                      >
+                        Review
+                      </button>
+                    </div>
                   </div>
                 ))}
               </div>

--- a/src/features/songs/songSlice.ts
+++ b/src/features/songs/songSlice.ts
@@ -2,7 +2,13 @@ import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import axios from 'axios';
 import { API_BASE_URL } from '../../helpers/constants';
 import { getAuthHeader } from '../../helpers/getAuthHeader';
-import { SongDetailSchema, CreatedSongSchema, type SongDetail, type CreatedSong } from '../../lib/schemas/song';
+import { SongDetailSchema, CreatedSongSchema, DifficultySchema, SavedBeatmapSchema, type SongDetail, type CreatedSong, type BeatmapUpload, type Difficulty } from '../../lib/schemas/song';
+import { handleThunkError } from '../../helpers/handleThunkError';
+import { validateOrReject } from '../../helpers/validateApi';
+import { uploadAssetWithPresigned } from '../../helpers/uploadAsset';
+
+// Asset type id for beatmap notes_data JSON uploads.
+const BEATMAP_ASSET_TYPE_ID = 4;
 
 export type CreateSongPayload = {
   song_title: string;
@@ -22,6 +28,7 @@ type Song = {
     created_at: string;
     updated_at: string;
     deleted_at?: string | null;
+    beatmaps?: { difficulty_name: string }[];
 }
 
 type SongState = {
@@ -31,6 +38,7 @@ type SongState = {
     selectedSong: SongDetail | null;
     selectedSongLoading: boolean;
     selectedSongError: string | null;
+    difficulties: Difficulty[];
 }
 
 const initialState: SongState = {
@@ -40,6 +48,7 @@ const initialState: SongState = {
     selectedSong: null,
     selectedSongLoading: false,
     selectedSongError: null,
+    difficulties: [],
 }
 
 export const fetchSongs = createAsyncThunk('songs/fetchSongs', async () => {
@@ -61,6 +70,7 @@ export const fetchSongById = createAsyncThunk<
         // Validate response with Zod
         const parsed = SongDetailSchema.safeParse(response.data.data);
         if (!parsed.success) {
+            console.error('Song detail validation failed:', parsed.error);
             return thunkAPI.rejectWithValue('Invalid song data received from server');
         }
         
@@ -98,6 +108,79 @@ export const createSong = createAsyncThunk<
             return thunkAPI.rejectWithValue(err.response?.data?.message || 'Failed to create song');
         }
         return thunkAPI.rejectWithValue('Failed to create song');
+    }
+});
+
+// Fetch the difficulty options (name -> id) used to build beatmap payloads.
+export const fetchDifficulties = createAsyncThunk<Difficulty[], void, { rejectValue: string }>(
+    'songs/fetchDifficulties',
+    async (_, thunkAPI) => {
+        try {
+            const response = await axios.get(`${API_BASE_URL}/difficulties`, { headers: getAuthHeader() });
+            // Endpoint returns a bare array; tolerate an optional { data } envelope.
+            const body = Array.isArray(response.data) ? response.data : response.data?.data;
+            return validateOrReject(DifficultySchema.array(), body, thunkAPI) as Difficulty[];
+        } catch (err) {
+            return handleThunkError(err, thunkAPI);
+        }
+    }
+);
+
+// Add, update, or approve a beatmap, accepting a partial payload: send
+// notes_data + counts to save a chart, or just is_approved to approve/reject.
+// difficulty_id always travels in the body. New beatmaps are created via
+// POST /beatmaps; existing ones (and approvals) are updated per-beatmap via
+// PUT /beatmaps/{song_id}/{beatmap_id}. Pass `beatmapId` (from the song's
+// beatmap list) to update; omit it to create. Saving a chart re-marks it
+// unapproved (backend's concern).
+export const saveBeatmap = createAsyncThunk<
+    SongDetail,
+    BeatmapUpload & { beatmapId?: number },
+    { rejectValue: string }
+>('songs/saveBeatmap', async ({ beatmapId, ...payload }, thunkAPI) => {
+    try {
+        // When saving a chart: notes_data holds the chart JSON (JSONB column),
+        // and the same JSON is also uploaded as an asset (type 4) whose id is
+        // carried on beatmap_assets_id.
+        let body: BeatmapUpload = payload;
+        if (payload.notes_data) {
+            const blob = new Blob([JSON.stringify(payload.notes_data)], { type: 'application/json' });
+            const filename = `beatmap_${payload.song_id}_${payload.difficulty_id}.json`;
+            const asset = await uploadAssetWithPresigned(blob, filename, 'application/json', BEATMAP_ASSET_TYPE_ID);
+            body = { ...payload, beatmap_assets_id: asset.id };
+        }
+
+        const response = beatmapId != null
+            ? await axios.put(
+                `${API_BASE_URL}/beatmaps/${payload.song_id}/${beatmapId}`,
+                body,
+                { headers: getAuthHeader() }
+            )
+            : await axios.post(
+                `${API_BASE_URL}/beatmaps/add`,
+                body,
+                { headers: getAuthHeader() }
+            );
+
+        // The endpoint returns the saved beatmap record (not the whole song),
+        // so validate that, then re-fetch the song detail to refresh the list.
+        const saved = SavedBeatmapSchema.safeParse(response.data?.data ?? response.data);
+        if (!saved.success) {
+            console.error('Save beatmap validation failed:', saved.error);
+            return thunkAPI.rejectWithValue('Invalid beatmap data received from server');
+        }
+
+        const songResponse = await axios.get(
+            `${API_BASE_URL}/songs/${payload.song_id}`,
+            { headers: getAuthHeader() }
+        );
+        const parsed = SongDetailSchema.safeParse(songResponse.data?.data ?? songResponse.data);
+        if (!parsed.success) {
+            return thunkAPI.rejectWithValue('Invalid song data received from server');
+        }
+        return parsed.data;
+    } catch (err) {
+        return handleThunkError(err, thunkAPI);
     }
 });
 
@@ -174,6 +257,21 @@ const songSlice = createSlice({
             .addCase(createSong.rejected, (state, action) => {
                 state.loading = false;
                 state.error = action.payload ?? 'Failed to create song';
+            })
+            .addCase(saveBeatmap.pending, (state) => {
+                state.selectedSongLoading = true;
+                state.selectedSongError = null;
+            })
+            .addCase(saveBeatmap.fulfilled, (state, action) => {
+                state.selectedSongLoading = false;
+                state.selectedSong = action.payload;
+            })
+            .addCase(saveBeatmap.rejected, (state, action) => {
+                state.selectedSongLoading = false;
+                state.selectedSongError = action.payload ?? 'Failed to save beatmap';
+            })
+            .addCase(fetchDifficulties.fulfilled, (state, action) => {
+                state.difficulties = action.payload;
             })
             .addCase(deleteSong.pending, (state) => {
                 state.loading = true;

--- a/src/lib/schemas/song.ts
+++ b/src/lib/schemas/song.ts
@@ -1,11 +1,53 @@
 import { z } from 'zod';
 
+export const SchemaChartNoteSchema = z.object({
+  uuid: z.string(),
+  songPos: z.number(),
+  beat: z.number(),
+  label: z.string(),
+  lane: z.number().int().nonnegative(),
+});
+
+export const SchemaChartLinkSchema = z.object({
+  uuid: z.string(),
+  startNote: SchemaChartNoteSchema,
+  endNote: SchemaChartNoteSchema,
+});
+
+export const SchemaChartSchema = z.object({
+  uuid: z.string(),
+  laneCount: z.number().int().positive(),
+  notes: z.array(SchemaChartNoteSchema),
+  links: z.array(SchemaChartLinkSchema),
+});
+
+// The chart structure stored as JSONB in notes_data. This is the same
+// shape the editor exports/imports (bpm, offset, charts).
+export const NotesDataSchema = z.object({
+  song_id: z.number().int().nonnegative(),
+  difficulty: z.string(),
+  bpm: z.number().positive(),
+  offset: z.number(),
+  charts: z.array(SchemaChartSchema).min(1),
+});
+
 export const BeatmapSchema = z.object({
+  // The API returns the primary key as `beatmap_id`; also accept `id` as a
+  // fallback. Normalized to `id` below so callers use a single field.
   id: z.number().optional(),
+  beatmap_id: z.number().optional(),
   difficulty_name: z.string(),
   beatmap_asset_key: z.string(),
-  beatmap_asset_url: z.string().url(),
-});
+  // null while the asset hasn't been generated yet (e.g. just-saved draft).
+  beatmap_asset_url: z.string().url().nullable().optional(),
+  // The chart JSON (JSONB column). Editor loads from this directly.
+  notes_data: NotesDataSchema.nullable().optional(),
+  // Per-beatmap approval state.
+  is_approved: z.boolean().optional(),
+}).transform(({ beatmap_id, id, ...rest }) => ({
+  ...rest,
+  id: id ?? beatmap_id,
+}));
 
 export const SongDetailSchema = z.object({
   song_id: z.number(),
@@ -52,38 +94,57 @@ export const CreatedSongSchema = z.object({
   deleted_at: z.string().nullable().optional(),
 });
 
-export const SchemaChartNoteSchema = z.object({
-  uuid: z.string(),
-  songPos: z.number(),
-  beat: z.number(),
-  label: z.string(),
-  lane: z.number().int().nonnegative(),
-});
-
-export const SchemaChartLinkSchema = z.object({
-  uuid: z.string(),
-  startNote: SchemaChartNoteSchema,
-  endNote: SchemaChartNoteSchema,
-});
-
-export const SchemaChartSchema = z.object({
-  uuid: z.string(),
-  laneCount: z.number().int().positive(),
-  notes: z.array(SchemaChartNoteSchema),
-  links: z.array(SchemaChartLinkSchema),
-});
-
 export const ImportedBeatmapSchema = z.object({
   bpm: z.number().positive(),
   offset: z.number(),
   charts: z.array(SchemaChartSchema).min(1),
 });
 
+// A difficulty option from GET /difficulties (name -> id resolution).
+export const DifficultySchema = z.object({
+  id: z.number().int().positive(),
+  name: z.string(),
+});
+
+// Payload sent to the backend when adding/updating/approving a beatmap.
+// Only the fields that need changing are sent (partial). For approval,
+// send just { song_id, difficulty_id, is_approved }.
+export const BeatmapUploadSchema = z.object({
+  song_id: z.number().int().nonnegative(),
+  difficulty_id: z.number().int().positive(),
+  notes_data: NotesDataSchema.optional(),
+  // Id of the uploaded notes_data JSON asset (asset type 4).
+  beatmap_assets_id: z.number().int().positive().optional(),
+  note_count: z.number().int().nonnegative().optional(),
+  hold_count: z.number().int().nonnegative().optional(),
+  max_combo: z.number().int().nonnegative().optional(),
+  is_approved: z.boolean().optional(),
+});
+
+// Response returned by POST/PUT /beatmaps — the saved beatmap record.
+// notes_data is loosely typed (passthrough) since we only need the metadata here.
+export const SavedBeatmapSchema = z.object({
+  id: z.number().int().positive(),
+  song_id: z.number().int().nonnegative(),
+  difficulty_id: z.number().int().positive(),
+  difficulty: z.string().optional(),
+  beatmap_asset_url: z.string().nullable().optional(),
+  note_count: z.number().int().nonnegative().optional(),
+  hold_count: z.number().int().nonnegative().optional(),
+  max_combo: z.number().int().nonnegative().optional(),
+  is_approved: z.boolean().optional(),
+}).passthrough();
+
+export type SavedBeatmap = z.infer<typeof SavedBeatmapSchema>;
+
 export type Beatmap = z.infer<typeof BeatmapSchema>;
 export type SongDetail = z.infer<typeof SongDetailSchema>;
 export type SongDetailResponse = z.infer<typeof SongDetailResponseSchema>;
 export type CreatedSong = z.infer<typeof CreatedSongSchema>;
 export type ImportedBeatmap = z.infer<typeof ImportedBeatmapSchema>;
+export type BeatmapUpload = z.infer<typeof BeatmapUploadSchema>;
+export type Difficulty = z.infer<typeof DifficultySchema>;
+export type NotesData = z.infer<typeof NotesDataSchema>;
 export type SchemaChartNote = z.infer<typeof SchemaChartNoteSchema>;
 export type SchemaChartLink = z.infer<typeof SchemaChartLinkSchema>;
 export type SchemaChart = z.infer<typeof SchemaChartSchema>;

--- a/src/pages/BeatmapEditor.tsx
+++ b/src/pages/BeatmapEditor.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, useMemo, useCallback } from 'react'
 import type { ChangeEvent } from 'react'
-import { useParams, useNavigate } from 'react-router-dom'
+import { useParams, useNavigate, useSearchParams } from 'react-router-dom'
 import { useDispatch, useSelector } from 'react-redux'
 import { 
   TimelineViewport,
@@ -10,9 +10,9 @@ import {
 import '@gamewota/beatmap-editor/style.css'
 import Container from '../components/Container'
 import { useToast } from '../hooks/useToast'
-import { fetchSongById, clearSelectedSong } from '../features/songs/songSlice'
+import { fetchSongById, clearSelectedSong, saveBeatmap, fetchDifficulties } from '../features/songs/songSlice'
 import type { RootState, AppDispatch } from '../store'
-import { ImportedBeatmapSchema, type Beatmap } from '../lib/schemas/song'
+import { ImportedBeatmapSchema, type Beatmap, type ImportedBeatmap } from '../lib/schemas/song'
 import {
   Header,
   Controls,
@@ -21,6 +21,57 @@ import {
   Stats,
 } from '../components/BeatmapEditor'
 import type { EditorNote } from '../components/BeatmapEditor/types'
+
+// Parse a validated beatmap JSON object into the editor's note model.
+// Shared by file-import and loading an existing beatmap from the CDN.
+// Per docs: cross-lane links are dropped (their endpoints stay as taps).
+function parseBeatmapData(data: ImportedBeatmap): {
+  notes: EditorNote[]
+  bpm: number
+  offsetMs: number
+  chartUuid: string
+} {
+  const chart = data.charts[0]
+  const importedOffset = data.offset
+
+  const heldNoteUuids = new Set<string>()
+  const importedNotes: EditorNote[] = []
+
+  chart.links.forEach((link) => {
+    if (link.startNote.lane !== link.endNote.lane) return
+    heldNoteUuids.add(link.startNote.uuid)
+    heldNoteUuids.add(link.endNote.uuid)
+    const startTime = (link.startNote.songPos + importedOffset) / 1000
+    const endTime = (link.endNote.songPos + importedOffset) / 1000
+    importedNotes.push({
+      id: link.startNote.uuid,
+      type: 'hold',
+      lane: link.startNote.lane,
+      time: startTime,
+      duration: Math.max(0, endTime - startTime),
+    })
+  })
+
+  chart.notes.forEach((note) => {
+    if (heldNoteUuids.has(note.uuid)) return
+    importedNotes.push({
+      id: note.uuid,
+      type: 'tap',
+      lane: note.lane,
+      time: (note.songPos + importedOffset) / 1000,
+    })
+  })
+
+  return {
+    notes: importedNotes,
+    bpm: data.bpm,
+    offsetMs: importedOffset,
+    chartUuid: chart.uuid,
+  }
+}
+
+// No-op notes handler for review (read-only) mode — discards any edit attempt.
+const noopNotesChange = () => {}
 
 // Available songs for editing (fallback when no song_id param)
 const AVAILABLE_SONGS: BeatmapSong[] = [
@@ -38,8 +89,11 @@ const AVAILABLE_SONGS: BeatmapSong[] = [
 export default function BeatmapEditorPage() {
   const { song_id } = useParams<{ song_id?: string }>();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const isReviewMode = searchParams.get('mode') === 'review';
+  const initialDifficulty = searchParams.get('difficulty');
   const dispatch = useDispatch<AppDispatch>();
-  const { selectedSong, selectedSongLoading, selectedSongError } = useSelector((state: RootState) => state.songs);
+  const { selectedSong, selectedSongLoading, selectedSongError, difficulties } = useSelector((state: RootState) => state.songs);
   
   const { showToast, ToastContainer } = useToast()
   
@@ -48,6 +102,8 @@ export default function BeatmapEditorPage() {
   const [song, setSong] = useState<BeatmapSong>(AVAILABLE_SONGS[0]);
   const [availableBeatmaps, setAvailableBeatmaps] = useState<Beatmap[]>([]);
   const [selectedDifficulty, setSelectedDifficulty] = useState<string>('');
+  const [isSaving, setIsSaving] = useState(false);
+  const [isApproving, setIsApproving] = useState(false);
   
   // Notes state
   const [notes, setNotes] = useState<EditorNote[]>([])
@@ -92,6 +148,23 @@ export default function BeatmapEditorPage() {
   
   // Create shared viewport
   const viewport = useMemo(() => new TimelineViewport(0, 800), [])
+
+  // Completeness is informational only (a song isn't fully playable until all
+  // difficulties exist). Approval is per-beatmap and not gated on this.
+  // Difficulties from /difficulties that have no saved beatmap on this song.
+  const missingDifficulties = useMemo(() => {
+    if (difficulties.length === 0) return []
+    const saved = new Set(availableBeatmaps.map((bm) => bm.difficulty_name.toLowerCase()))
+    return difficulties.filter((d) => !saved.has(d.name.toLowerCase()))
+  }, [difficulties, availableBeatmaps])
+
+  // Approval state of the currently selected difficulty's beatmap (if saved).
+  const isSelectedApproved = useMemo(() => {
+    const bm = availableBeatmaps.find(
+      (b) => b.difficulty_name.toLowerCase() === selectedDifficulty.toLowerCase(),
+    )
+    return bm?.is_approved === true
+  }, [availableBeatmaps, selectedDifficulty])
   
   // Fetch song data when song_id param is present
   useEffect(() => {
@@ -106,6 +179,13 @@ export default function BeatmapEditorPage() {
       dispatch(clearSelectedSong());
     };
   }, [song_id, dispatch]);
+
+  // Load difficulty options (name -> id) needed to build the save payload.
+  useEffect(() => {
+    if (difficulties.length === 0) {
+      dispatch(fetchDifficulties());
+    }
+  }, [dispatch, difficulties.length]);
   
   // Update song object when API data is loaded
   useEffect(() => {
@@ -130,13 +210,29 @@ export default function BeatmapEditorPage() {
       });
       
       const beatmaps = selectedSong.beatmaps || [];
-      setAvailableBeatmaps(beatmaps);
+      // Honor a difficulty passed via query (e.g. from the review entry point),
+      // otherwise default to easy.
+      const requestedBeatmap = initialDifficulty
+        ? beatmaps.find((bm) => bm.difficulty_name.toLowerCase() === initialDifficulty.toLowerCase())
+        : undefined;
       const easyBeatmap = beatmaps.find(
         (bm) => bm.difficulty_name.toLowerCase() === 'easy',
       );
-      setSelectedDifficulty(easyBeatmap?.difficulty_name ?? '');
+      setSelectedDifficulty((requestedBeatmap ?? easyBeatmap)?.difficulty_name ?? '');
       setBpm(120);
       bpmDetectedRef.current.clear();
+    }
+    // Keyed on song identity so a save-triggered refresh of selectedSong doesn't
+    // reset the user's selected difficulty / bpm. availableBeatmaps is synced
+    // separately below so completeness still updates on refresh.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isSpecificSongMode, selectedSong?.song_id, initialDifficulty]);
+
+  // Keep the beatmap list in sync on every selectedSong refresh (e.g. after a
+  // save) so the difficulty dropdown and completeness banner stay accurate.
+  useEffect(() => {
+    if (isSpecificSongMode && selectedSong) {
+      setAvailableBeatmaps(selectedSong.beatmaps || []);
     }
   }, [isSpecificSongMode, selectedSong]);
   
@@ -186,6 +282,35 @@ export default function BeatmapEditorPage() {
     setBpm(songBpmRef.current)
   }, [song.id])
   
+  // Load the existing chart directly from the beatmap's notes_data when a
+  // difficulty is selected, hydrating notes/bpm/offset so admins edit the
+  // current chart instead of a blank one. (No CDN fetch — notes_data is the
+  // JSONB stored on the beatmap record and works even before the asset exists.)
+  useEffect(() => {
+    if (!isSpecificSongMode || !selectedDifficulty) return
+
+    const beatmap = availableBeatmaps.find(
+      (bm) => bm.difficulty_name === selectedDifficulty,
+    )
+    const notesData = beatmap?.notes_data
+    if (!notesData) return
+
+    const validation = ImportedBeatmapSchema.safeParse(notesData)
+    if (!validation.success) {
+      console.error('Existing beatmap validation failed:', validation.error)
+      showToastRef.current('Existing beatmap has an invalid format', 'error')
+      return
+    }
+
+    const parsed = parseBeatmapData(validation.data)
+    chartUuidRef.current = parsed.chartUuid
+    setNotes(parsed.notes)
+    setBpm(parsed.bpm)
+    setOffsetMs(parsed.offsetMs)
+    // BPM/offset come from the saved chart; don't let detection overwrite them.
+    bpmDetectedRef.current.add(song.id)
+  }, [isSpecificSongMode, selectedDifficulty, availableBeatmaps, song.id])
+
   // Update viewport when duration or zoom changes
   useEffect(() => {
     viewport.setDuration(duration * 1000 || song.duration * 1000)
@@ -281,8 +406,9 @@ export default function BeatmapEditorPage() {
     setCurrentTime(0)
   }, [])
   
-  // Export beatmap
-  const handleExport = useCallback(() => {
+  // Build the beatmap payload from the current editor state.
+  // Shared by Export (download) and Save (upload to backend) so both stay in sync.
+  const buildBeatmapPayload = useCallback(() => {
     const beatDurationMs = bpm > 0 ? 60000 / bpm : 0
     const toSchemaNote = (
       uuid: string,
@@ -324,7 +450,8 @@ export default function BeatmapEditorPage() {
       }
     })
 
-    const beatmapData = {
+    // The chart structure (stored as JSONB in notes_data, also the export format).
+    const notesData = {
       song_id: parseInt(song.id, 10) || 0,
       difficulty: selectedDifficulty || 'default',
       bpm,
@@ -339,7 +466,25 @@ export default function BeatmapEditorPage() {
       ],
     }
 
-    const blob = new Blob([JSON.stringify(beatmapData, null, 2)], { type: 'application/json' })
+    // Editor-level counts (taps + holds = total notes; holds tracked separately).
+    const holdCount = notes.filter(
+      (n) => n.type === 'hold' && n.duration && n.duration > 0,
+    ).length
+
+    return {
+      notesData,
+      noteCount: notes.length,
+      holdCount,
+      // Each note contributes 1 to combo (holds count once); refine if scoring differs.
+      maxCombo: notes.length,
+    }
+  }, [song.id, notes, selectedDifficulty, bpm, offsetMs])
+
+  // Export beatmap (download as JSON file)
+  const handleExport = useCallback(() => {
+    const { notesData } = buildBeatmapPayload()
+
+    const blob = new Blob([JSON.stringify(notesData, null, 2)], { type: 'application/json' })
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
     a.href = url
@@ -351,8 +496,122 @@ export default function BeatmapEditorPage() {
     a.click()
     document.body.removeChild(a)
     URL.revokeObjectURL(url)
-  }, [song, notes, selectedDifficulty, bpm, offsetMs])
-  
+  }, [buildBeatmapPayload, song.title, selectedDifficulty])
+
+  // Save beatmap to the backend. New difficulties are created (POST); existing
+  // ones are updated (PUT /beatmaps/:song_id/:difficulty_id). Saving always
+  // submits as unapproved so the chart goes back through review.
+  const handleSave = useCallback(async () => {
+    if (!isSpecificSongMode) {
+      showToastRef.current('Open a song from the dashboard to save', 'warning')
+      return
+    }
+    if (!selectedDifficulty) {
+      showToastRef.current('Select a difficulty before saving', 'warning')
+      return
+    }
+
+    const difficulty = difficulties.find(
+      (d) => d.name.toLowerCase() === selectedDifficulty.toLowerCase(),
+    )
+    if (!difficulty) {
+      showToastRef.current(`Unknown difficulty "${selectedDifficulty}"`, 'error')
+      return
+    }
+
+    const { notesData, noteCount, holdCount, maxCombo } = buildBeatmapPayload()
+    // If this difficulty already has a saved beatmap, update it by its id; else create.
+    const existing = availableBeatmaps.find(
+      (bm) => bm.difficulty_name.toLowerCase() === selectedDifficulty.toLowerCase(),
+    )
+    // Updates require a beatmap id — fail loudly rather than silently creating a duplicate.
+    if (existing && existing.id == null) {
+      showToastRef.current('Cannot update this beatmap: missing beatmap id', 'error')
+      return
+    }
+
+    setIsSaving(true)
+    try {
+      await dispatch(
+        saveBeatmap({
+          song_id: parseInt(song.id, 10) || 0,
+          difficulty_id: difficulty.id,
+          notes_data: notesData,
+          note_count: noteCount,
+          hold_count: holdCount,
+          max_combo: maxCombo,
+          is_approved: false,
+          beatmapId: existing?.id,
+        }),
+      ).unwrap()
+      // After saving, warn if the song still lacks other difficulties.
+      // (availableBeatmaps updates via the refreshed selectedSong; recompute
+      //  the gap optimistically by excluding the one we just saved.)
+      const stillMissing = missingDifficulties.filter(
+        (d) => d.name.toLowerCase() !== selectedDifficulty.toLowerCase(),
+      )
+      if (stillMissing.length > 0) {
+        showToastRef.current(
+          `${selectedDifficulty} saved. Still missing: ${stillMissing.map((d) => d.name).join(', ')}`,
+          'warning',
+        )
+      } else {
+        showToastRef.current('Beatmap saved — all difficulties complete, pending approval', 'success')
+      }
+    } catch (error) {
+      const message = typeof error === 'string' ? error : 'Failed to save beatmap'
+      showToastRef.current(message, 'error')
+    } finally {
+      setIsSaving(false)
+    }
+  }, [isSpecificSongMode, selectedDifficulty, difficulties, buildBeatmapPayload, availableBeatmaps, missingDifficulties, song.id, dispatch])
+
+  // Approve or reject the beatmap under review. Sends only is_approved via PUT
+  // so the reviewed chart is never altered by the approval action itself.
+  const handleApproval = useCallback(async (isApproved: boolean) => {
+    const difficulty = difficulties.find(
+      (d) => d.name.toLowerCase() === selectedDifficulty.toLowerCase(),
+    )
+    if (!difficulty) {
+      showToastRef.current(`Unknown difficulty "${selectedDifficulty}"`, 'error')
+      return
+    }
+
+    // Approval is per-beatmap, so its id is required.
+    const existing = availableBeatmaps.find(
+      (bm) => bm.difficulty_name.toLowerCase() === selectedDifficulty.toLowerCase(),
+    )
+    if (existing?.id == null) {
+      showToastRef.current('Cannot find this beatmap to approve', 'error')
+      return
+    }
+
+    setIsApproving(true)
+    try {
+      await dispatch(
+        saveBeatmap({
+          song_id: parseInt(song.id, 10) || 0,
+          difficulty_id: difficulty.id,
+          is_approved: isApproved,
+          beatmapId: existing.id,
+        }),
+      ).unwrap()
+      showToastRef.current(
+        isApproved
+          ? 'Beatmap approved'
+          : isSelectedApproved
+            ? 'Approval removed'
+            : 'Beatmap rejected',
+        isApproved ? 'success' : 'warning',
+      )
+    } catch (error) {
+      const message = typeof error === 'string' ? error : 'Failed to update approval'
+      showToastRef.current(message, 'error')
+    } finally {
+      setIsApproving(false)
+    }
+  }, [difficulties, selectedDifficulty, availableBeatmaps, isSelectedApproved, song.id, dispatch])
+
   // Import beatmap
   const handleImport = useCallback((event: ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0]
@@ -370,44 +629,11 @@ export default function BeatmapEditorPage() {
           return
         }
 
-        const data = validationResult.data
-        const chart = data.charts[0]
-        const importedOffset = data.offset
-
-        // Pair up notes connected by same-lane links as hold notes.
-        // Per docs: cross-lane links are dropped (their endpoints stay as taps).
-        const heldNoteUuids = new Set<string>()
-        const importedNotes: EditorNote[] = []
-
-        chart.links.forEach((link) => {
-          if (link.startNote.lane !== link.endNote.lane) return
-          heldNoteUuids.add(link.startNote.uuid)
-          heldNoteUuids.add(link.endNote.uuid)
-          const startTime = (link.startNote.songPos + importedOffset) / 1000
-          const endTime = (link.endNote.songPos + importedOffset) / 1000
-          importedNotes.push({
-            id: link.startNote.uuid,
-            type: 'hold',
-            lane: link.startNote.lane,
-            time: startTime,
-            duration: Math.max(0, endTime - startTime),
-          })
-        })
-
-        chart.notes.forEach((note) => {
-          if (heldNoteUuids.has(note.uuid)) return
-          importedNotes.push({
-            id: note.uuid,
-            type: 'tap',
-            lane: note.lane,
-            time: (note.songPos + importedOffset) / 1000,
-          })
-        })
-
-        chartUuidRef.current = chart.uuid
-        setNotes(importedNotes)
-        setBpm(data.bpm)
-        setOffsetMs(importedOffset)
+        const parsed = parseBeatmapData(validationResult.data)
+        chartUuidRef.current = parsed.chartUuid
+        setNotes(parsed.notes)
+        setBpm(parsed.bpm)
+        setOffsetMs(parsed.offsetMs)
         showToast('Beatmap imported successfully', 'success')
       } catch (error) {
         console.error('Failed to parse beatmap file:', error)
@@ -476,10 +702,38 @@ export default function BeatmapEditorPage() {
           song={song}
           availableSongs={AVAILABLE_SONGS}
           availableBeatmaps={availableBeatmaps}
+          difficulties={difficulties}
           selectedDifficulty={selectedDifficulty}
           onSongChange={setSong}
           onSelectedDifficultyChange={setSelectedDifficulty}
+          isReviewMode={isReviewMode}
+          isApproving={isApproving}
+          isSelectedApproved={isSelectedApproved}
+          onApprove={() => handleApproval(true)}
+          onReject={() => handleApproval(false)}
         />
+
+        {isSpecificSongMode && difficulties.length > 0 && (
+          missingDifficulties.length > 0 ? (
+            <div role="alert" className="alert alert-warning">
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M5.07 19h13.86A2 2 0 0020.66 16L13.73 4a2 2 0 00-3.46 0L3.34 16A2 2 0 005.07 19z" />
+              </svg>
+              <span>
+                <strong>{difficulties.length - missingDifficulties.length}/{difficulties.length} difficulties saved.</strong>{' '}
+                A song needs all difficulties to go live. Missing:{' '}
+                {missingDifficulties.map((d) => d.name).join(', ')}.
+              </span>
+            </div>
+          ) : (
+            <div role="alert" className="alert alert-success">
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+              </svg>
+              <span>All {difficulties.length} difficulties saved — song is complete.</span>
+            </div>
+          )
+        )}
 
         <Controls
           isPlaying={isPlaying}
@@ -502,6 +756,9 @@ export default function BeatmapEditorPage() {
           onBpmChange={setBpm}
           onExport={handleExport}
           onImport={handleImport}
+          onSave={isSpecificSongMode && !isReviewMode ? handleSave : undefined}
+          isSaving={isSaving}
+          canSave={!!selectedDifficulty}
         />
 
         <audio
@@ -535,7 +792,8 @@ export default function BeatmapEditorPage() {
           offsetMs={offsetMs}
           sfxEnabled={sfxEnabled}
           sfxUrl={sfxUrl}
-          onNotesChange={setNotes}
+          // Review mode is read-only: discard edits so the chart can't change.
+          onNotesChange={isReviewMode ? noopNotesChange : setNotes}
         />
 
         <Stats

--- a/src/pages/Song.tsx
+++ b/src/pages/Song.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, type ReactNode } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
-import { fetchSongs, fetchSongById, clearSelectedSong, deleteSong } from '../features/songs/songSlice';
+import { fetchSongs, fetchSongById, clearSelectedSong, deleteSong, fetchDifficulties } from '../features/songs/songSlice';
 import type { RootState, AppDispatch } from '../store';
 import { DataTable } from '../components/DataTable';
 import Container from '../components/Container';
@@ -18,6 +18,7 @@ type Song = {
   song_assets: string | null;
   created_at: string;
   updated_at: string;
+  beatmaps?: { difficulty_name: string }[];
 };
 
 type Column<T> = {
@@ -28,7 +29,7 @@ type Column<T> = {
 const Song = () => {
     const dispatch = useDispatch<AppDispatch>();
     const navigate = useNavigate();
-    const { data, loading, error, selectedSong, selectedSongLoading, selectedSongError } = useSelector((state: RootState) => state.songs);
+    const { data, loading, error, selectedSong, selectedSongLoading, selectedSongError, difficulties } = useSelector((state: RootState) => state.songs);
     const [isDetailModalOpen, setIsDetailModalOpen] = useState(false);
     const [isAddModalOpen, setIsAddModalOpen] = useState(false);
     const [deleteConfirm, setDeleteConfirm] = useState<{ songId: number; songTitle: string } | null>(null);
@@ -97,18 +98,33 @@ const Song = () => {
                     >
                         Detail
                     </Button>
-                    <Button 
-                        variant="primary"
-                        size="sm"
-                        disabled={!row.song_id}
-                        onClick={() => {
-                            if (row.song_id != null) {
-                                handleEditBeatmapClick(row.song_id);
-                            }
-                        }}
-                    >
-                        Edit Beatmap
-                    </Button>
+                    <div className="flex items-center gap-1">
+                        <Button
+                            variant="primary"
+                            size="sm"
+                            disabled={!row.song_id}
+                            onClick={() => {
+                                if (row.song_id != null) {
+                                    handleEditBeatmapClick(row.song_id);
+                                }
+                            }}
+                        >
+                            {row.beatmaps && row.beatmaps.length > 0 ? 'Edit Beatmap' : 'Add Beatmap'}
+                        </Button>
+                        {difficulties.length > 0 && (() => {
+                            const have = row.beatmaps?.length ?? 0;
+                            const total = difficulties.length;
+                            const complete = have >= total;
+                            return (
+                                <span
+                                    className={`badge badge-sm ${complete ? 'badge-success' : 'badge-warning'}`}
+                                    title={complete ? 'All difficulties present' : 'Missing difficulties — song not playable until complete'}
+                                >
+                                    {have}/{total}{complete ? ' ✓' : ''}
+                                </span>
+                            );
+                        })()}
+                    </div>
                     <Button 
                         variant="error"
                         size="sm"
@@ -128,6 +144,7 @@ const Song = () => {
 
     useEffect(() => {
         dispatch(fetchSongs());
+        dispatch(fetchDifficulties());
     }, [dispatch]);
 
     if (loading) return (


### PR DESCRIPTION


- Save beatmaps to the backend (POST /beatmaps/add for new, PUT /beatmaps/:song_id/:beatmap_id for updates) with difficulty_id resolved from /difficulties; upload notes_data JSON as an asset (type 4) and carry beatmap_assets_id on the payload
- Load existing charts directly from each beatmap's notes_data
- Add review mode (?mode=review) reusing the editor read-only, with per-beatmap Approve/Reject; show Approved badge + Revoke when already approved
- Songs page: "Add Beatmap" wording + completeness badge; editor shows a completeness banner for missing difficulties (informational only)
- Song detail modal: per-beatmap approval badge and Review entry point
- Normalize beatmap id (accept beatmap_id), validate save/difficulty responses with Zod

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added beatmap save functionality with save state tracking
  * Introduced review mode for beatmaps enabling approval/rejection workflow
  * Added difficulty management and selection for beatmap editing
  * Added difficulty completion badges to track beatmap coverage per difficulty
  * Introduced beatmap approval status tracking with approval badges

<!-- end of auto-generated comment: release notes by coderabbit.ai -->