### PR TITLE
feat(profile-banner): add profile banner list and create flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,85 +1,22 @@
-import Sidebar from "./components/Sidebar"
-import {Route, Routes} from 'react-router-dom'
-import { Suspense, lazy } from 'react'
-import Home from "./pages/Home"
-import Card from "./pages/Card"
-import Song from "./pages/Song"
-import Quote from "./pages/Quote"
-import User from "./pages/User"
-import Item from "./pages/Item"
-import Role from "./pages/Role"
-import ShopTransactions from "./pages/ShopTransactions"
-import TransactionLog from './pages/TransactionLog'
-import ForgotPassword from "./pages/ForgotPassword"
-import VerifyUser from "./pages/VerifyUser"
-import ResendVerification from "./pages/ResendVerification"
-import { useAuth } from "./hooks/useAuth"
-import Permission from "./pages/Permissions"
-import GameItemsType from "./pages/GameItemsType"
-import GameItems from "./pages/GameItems"
-import Element from "./pages/Element"
-import Assets from "./pages/Assets"
-import News from "./pages/News"
-import NewsDetail from "./pages/NewsDetail"
-import NewsType from "./pages/NewsType"
-import CardVariant from "./pages/CardVariant"
-import GachaPack from "./pages/GachaPack"
-import GachaPackDetails from "./pages/GachaPackDetails"
-import Member from "./pages/Member"
-import Rarity from "./pages/Rarity"
-import Currency from "./pages/Currency"
-import BeatmapEditor from "./pages/BeatmapEditor"
-
-// Lazy-loaded pages
-const Events = lazy(() => import("./pages/Events"))
-const EventDetail = lazy(() => import("./pages/EventDetail"))
-const BannerType = lazy(() => import("./pages/BannerType"))
-const Banner = lazy(() => import("./pages/Banner"))
-
+import { Suspense } from 'react'
+import Sidebar from './components/Sidebar'
+import AppRoutes from './routes/AppRoutes'
+import { useAuth } from './hooks/useAuth'
 
 function App() {
   const auth = useAuth()
   return (
     <div data-theme="bumblebee" className="min-h-screen w-screen">
-      {auth.user && (
-        <Sidebar />
-      )}
+      {auth.user && <Sidebar />}
 
-      <Suspense fallback={<div className="flex items-center justify-center h-screen"><span className="loading loading-spinner loading-lg"></span></div>}>
-      <Routes>
-        <Route path="/dashboard/" element={<Home />}/>
-        <Route path="/dashboard/cards" element={<Card />}/>
-        <Route path="/dashboard/cards/variant" element={<CardVariant />}/>
-        <Route path="/dashboard/cards/gacha-pack" element={<GachaPack />}/>
-        <Route path="/dashboard/cards/gacha-pack/:id" element={<GachaPackDetails />}/>
-        <Route path="/dashboard/songs" element={<Song />}/>
-        <Route path="/dashboard/quotes" element={<Quote />}/>
-        <Route path="/dashboard/users" element={<User />}/>
-        <Route path="/dashboard/items" element={<Item />}/>
-        <Route path="/dashboard/shop-history" element={<ShopTransactions />}/>
-        <Route path="/dashboard/transaction-log" element={<TransactionLog />}/>
-        <Route path="/dashboard/forgot-password" element={<ForgotPassword />}/>
-        <Route path="/dashboard/verify" element={<VerifyUser />}/>
-        <Route path="/dashboard/resend-verify" element={<ResendVerification />}/>
-        <Route path="/dashboard/role" element={<Role />} />
-        <Route path="/dashboard/permissions" element={<Permission />} />
-        <Route path="/dashboard/element" element={<Element />} />
-        <Route path="/dashboard/game-items" element={<GameItems />} />
-        <Route path="/dashboard/game-items-type" element={<GameItemsType />} />
-        <Route path="/dashboard/assets" element={<Assets />} />
-        <Route path="/dashboard/news" element={<News />} />
-        <Route path="/dashboard/news/:id" element={<NewsDetail />} />
-        <Route path="/dashboard/news-type" element={<NewsType />} />
-        <Route path="/dashboard/member" element={<Member />} />
-        <Route path="/dashboard/rarity" element={<Rarity />} />
-        <Route path="/dashboard/currency" element={<Currency />} />
-        <Route path="/dashboard/beatmap-editor" element={<BeatmapEditor />} />
-        <Route path="/dashboard/:song_id/beatmap-editor" element={<BeatmapEditor />} />
-        <Route path="/dashboard/events" element={<Events />} />
-        <Route path="/dashboard/events/:id" element={<EventDetail />} />
-        <Route path="/dashboard/banner-types" element={<BannerType />} />
-        <Route path="/dashboard/banners" element={<Banner />} />
-      </Routes>
+      <Suspense
+        fallback={
+          <div className="flex items-center justify-center h-screen">
+            <span className="loading loading-spinner loading-lg"></span>
+          </div>
+        }
+      >
+        <AppRoutes />
       </Suspense>
     </div>
   )

--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -3,15 +3,23 @@ import React from 'react';
 type ContainerProps = {
   children: React.ReactNode;
   className?: string;
+  // Horizontal alignment of the content. Defaults to centered.
+  justify?: 'start' | 'center' | 'end';
 };
 
+const JUSTIFY_CLASS = {
+  start: 'justify-start',
+  center: 'justify-center',
+  end: 'justify-end',
+} as const;
+
 // Reusable layout container to avoid repeating tailwind wrapper classes
-export default function Container({ children, className = '' }: ContainerProps) {
+export default function Container({ children, className = '', justify = 'center' }: ContainerProps) {
   return (
     <div className={[
       'w-screen',
       'flex',
-      'justify-center',
+      JUSTIFY_CLASS[justify],
       'p-10',
       className,
     ].filter(Boolean).join(' ')}>

--- a/src/components/sidebarConfig.tsx
+++ b/src/components/sidebarConfig.tsx
@@ -77,6 +77,7 @@ export const sidebarMenu: MenuItem[] = [
       { key: 'users', label: 'Users', path: '/dashboard/users', icon: Icons.Users, permission: 'user.view' },
       { key: 'roles', label: 'Roles', path: '/dashboard/role', icon: Icons.Role, permission: 'role.view' },
       { key: 'permissions', label: 'Permissions', path: '/dashboard/permissions', icon: Icons.Role, permission: 'permission.view' },
+      { key: 'profile-banner', label: 'Profile Banners', path: '/dashboard/profile-banner', icon: Icons.News, permission: 'banners.view' },
     ],
   },
   {

--- a/src/features/gameItems/gameItemsSlice.ts
+++ b/src/features/gameItems/gameItemsSlice.ts
@@ -4,6 +4,7 @@ import { API_BASE_URL } from '../../helpers/constants';
 import { getAuthHeader } from '../../helpers/getAuthHeader';
 import { handleThunkError } from '../../helpers/handleThunkError';
 import { uploadAssetWithPresigned } from '../../helpers/uploadAsset';
+import { ASSET_TYPE } from '../../helpers/assetTypes';
 import { GameItemArraySchema, GameItemSchema, type GameItem } from '../../lib/schemas/gameItem';
 import { validateOrReject } from '../../helpers/validateApi';
 
@@ -63,7 +64,7 @@ export const createGameItem = createAsyncThunk<GameItemsType, {
                 if (!contentType || !contentType.startsWith('image/')) {
                     return thunkAPI.rejectWithValue('Only image files are allowed for game items');
                 }
-                const uploaded = await uploadAssetWithPresigned(assetFile, undefined, contentType, 1);
+                const uploaded = await uploadAssetWithPresigned(assetFile, undefined, contentType, ASSET_TYPE.ARTWORK);
                 asset_id = uploaded.id;
             }
 
@@ -110,7 +111,7 @@ export const updateGameItem = createAsyncThunk<GameItemsType, {
                 if (!contentType || !contentType.startsWith('image/')) {
                     return thunkAPI.rejectWithValue('Only image files are allowed for game items');
                 }
-                const uploaded = await uploadAssetWithPresigned(payload.assetFile, undefined, contentType, 1);
+                const uploaded = await uploadAssetWithPresigned(payload.assetFile, undefined, contentType, ASSET_TYPE.ARTWORK);
                 asset_id = uploaded.id;
             }
 

--- a/src/features/profileBanner/profileBannerSlice.ts
+++ b/src/features/profileBanner/profileBannerSlice.ts
@@ -1,0 +1,96 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import axios from 'axios';
+import { API_BASE_URL } from '../../helpers/constants';
+import { getAuthHeader } from '../../helpers/getAuthHeader';
+import { validateOrReject } from '../../helpers/validateApi';
+import { handleThunkError } from '../../helpers/handleThunkError';
+import { ProfileBannerListResponseSchema } from '../../lib/schemas/profileBanner';
+import type { ProfileBanner, ProfileBannerListResponse, ProfileBannerPayload } from '../../lib/schemas/profileBanner';
+
+interface ProfileBannerState {
+  banners: ProfileBanner[];
+  loading: boolean;
+  error: string | null;
+}
+
+const initialState: ProfileBannerState = {
+  banners: [],
+  loading: false,
+  error: null,
+};
+
+// Fetch all profile banners. The endpoint wraps the list in a
+// { statusCode, message, banners } envelope, so validate that and unwrap.
+export const fetchProfileBanners = createAsyncThunk<ProfileBanner[], void, { rejectValue: string }>(
+  'profileBanners/fetchAll',
+  async (_, thunkAPI) => {
+    try {
+      const response = await axios.get(`${API_BASE_URL}/profile-banners`, {
+        headers: getAuthHeader(),
+      });
+      const parsed = validateOrReject(
+        ProfileBannerListResponseSchema,
+        response.data,
+        thunkAPI,
+      ) as ProfileBannerListResponse;
+      return parsed.banners;
+    } catch (error: unknown) {
+      return handleThunkError(error, thunkAPI);
+    }
+  }
+);
+
+// Create a profile banner. asset_id is obtained beforehand via the presigned
+// upload flow. The list is refreshed by dispatching fetchProfileBanners after.
+export const createProfileBanner = createAsyncThunk<void, ProfileBannerPayload, { rejectValue: string }>(
+  'profileBanners/create',
+  async (payload, thunkAPI) => {
+    try {
+      await axios.post(`${API_BASE_URL}/profile-banners`, payload, {
+        headers: getAuthHeader(),
+      });
+    } catch (error: unknown) {
+      return handleThunkError(error, thunkAPI);
+    }
+  }
+);
+
+const profileBannerSlice = createSlice({
+  name: 'profileBanners',
+  initialState,
+  reducers: {
+    clearError: (state) => {
+      state.error = null;
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchProfileBanners.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(fetchProfileBanners.fulfilled, (state, action) => {
+        state.loading = false;
+        state.banners = action.payload;
+      })
+      .addCase(fetchProfileBanners.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload ?? 'Unknown error';
+      })
+      .addCase(createProfileBanner.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(createProfileBanner.fulfilled, (state) => {
+        state.loading = false;
+        // List is refreshed via a subsequent fetchProfileBanners().
+      })
+      .addCase(createProfileBanner.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload ?? 'Unknown error';
+      });
+  },
+});
+
+export const { clearError } = profileBannerSlice.actions;
+export default profileBannerSlice.reducer;

--- a/src/features/songs/songSlice.ts
+++ b/src/features/songs/songSlice.ts
@@ -6,9 +6,10 @@ import { SongDetailSchema, CreatedSongSchema, DifficultySchema, SavedBeatmapSche
 import { handleThunkError } from '../../helpers/handleThunkError';
 import { validateOrReject } from '../../helpers/validateApi';
 import { uploadAssetWithPresigned } from '../../helpers/uploadAsset';
+import { ASSET_TYPE } from '../../helpers/assetTypes';
 
 // Asset type id for beatmap notes_data JSON uploads.
-const BEATMAP_ASSET_TYPE_ID = 4;
+const BEATMAP_ASSET_TYPE_ID = ASSET_TYPE.BEATMAP;
 
 export type CreateSongPayload = {
   song_title: string;

--- a/src/helpers/assetTypes.ts
+++ b/src/helpers/assetTypes.ts
@@ -1,0 +1,15 @@
+// Asset type ids, mirrored from the backend. Used when requesting a presigned
+// upload URL (uploadAssetWithPresigned) so each asset lands in the right
+// storage folder. Keep in sync with the backend's ASSET_TYPE map.
+export const ASSET_TYPE = {
+  ARTWORK: 1,
+  SONG: 2,
+  MV: 3,
+  BEATMAP: 4,
+  CARD_ARTWORK: 5,
+  BANNER_ARTWORK: 6,
+  BANNER_VIDEO: 7,
+  ITEM_ARTWORK: 8,
+} as const;
+
+export type AssetTypeId = (typeof ASSET_TYPE)[keyof typeof ASSET_TYPE];

--- a/src/lib/schemas/profileBanner.ts
+++ b/src/lib/schemas/profileBanner.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+
+// Shape of a single profile banner row (joined with its asset for image_url).
+export const ProfileBannerSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  asset_id: z.number(),
+  image_url: z.string(),
+  is_default: z.boolean(),
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+
+export type ProfileBanner = z.infer<typeof ProfileBannerSchema>;
+
+// Envelope returned by GET /profile-banners.
+export const ProfileBannerListResponseSchema = z.object({
+  statusCode: z.number(),
+  message: z.string(),
+  banners: z.array(ProfileBannerSchema),
+});
+
+export type ProfileBannerListResponse = z.infer<typeof ProfileBannerListResponseSchema>;
+
+// Payload sent to POST /profile-banners. asset_id comes from the presigned
+// upload flow.
+export const ProfileBannerPayloadSchema = z.object({
+  name: z.string().min(1),
+  asset_id: z.number().int().positive(),
+  is_default: z.boolean(),
+});
+
+export type ProfileBannerPayload = z.infer<typeof ProfileBannerPayloadSchema>;

--- a/src/pages/ProfileBanner.tsx
+++ b/src/pages/ProfileBanner.tsx
@@ -1,0 +1,198 @@
+import { useEffect, useRef, useState } from 'react'
+import moment from 'moment'
+import { useDispatch, useSelector } from 'react-redux'
+import Container from '../components/Container'
+import { DataTable } from '../components/DataTable'
+import { Button } from '../components/Button'
+import Modal from '../components/Modal'
+import { useToast } from '../hooks/useToast'
+import { uploadAssetWithPresigned } from '../helpers/uploadAsset'
+import { ASSET_TYPE } from '../helpers/assetTypes'
+import { createProfileBanner, fetchProfileBanners } from '../features/profileBanner/profileBannerSlice'
+import type { ProfileBanner as ProfileBannerType } from '../lib/schemas/profileBanner'
+import type { RootState, AppDispatch } from '../store'
+
+type Column<T> = {
+  header: string
+  accessor: keyof T | ((row: T, index: number) => React.ReactNode)
+}
+
+const formatDate = (value?: string) =>
+  value && moment(value).isValid()
+    ? <span className="whitespace-nowrap">{moment(value).format('DD-MM-YYYY')}</span>
+    : '-'
+
+const columns: Column<ProfileBannerType>[] = [
+  { header: '#', accessor: (_row, i) => (i + 1) as React.ReactNode },
+  {
+    header: 'Image',
+    accessor: (row) =>
+      row.image_url
+        ? <img src={row.image_url} alt={row.name} className="h-16 w-28 object-cover rounded" />
+        : '-',
+  },
+  { header: 'Name', accessor: 'name' },
+  { header: 'Default', accessor: (row) => (row.is_default ? 'Yes' : 'No') },
+  { header: 'Created At', accessor: (row) => formatDate(row.created_at) },
+  { header: 'Updated At', accessor: (row) => formatDate(row.updated_at) },
+]
+
+const emptyForm = { name: '', asset_id: 0, is_default: false, previewUrl: '' }
+
+const ProfileBanner = () => {
+  const dispatch = useDispatch<AppDispatch>()
+  const { banners, loading, error } = useSelector((state: RootState) => state.profileBanners)
+  const { showToast, ToastContainer } = useToast()
+
+  const isMountedRef = useRef(true)
+  const [isCreateOpen, setIsCreateOpen] = useState(false)
+  const [form, setForm] = useState(emptyForm)
+  const [isUploading, setIsUploading] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
+
+  useEffect(() => {
+    isMountedRef.current = true
+    dispatch(fetchProfileBanners())
+    return () => {
+      isMountedRef.current = false
+    }
+  }, [dispatch])
+
+  const openCreate = () => {
+    setForm(emptyForm)
+    setIsCreateOpen(true)
+  }
+
+  const handleFileUpload = () => {
+    const input = document.createElement('input')
+    input.type = 'file'
+    input.accept = 'image/*'
+    input.onchange = async () => {
+      const file = input.files?.[0]
+      if (!file) return
+      setIsUploading(true)
+      try {
+        const asset = await uploadAssetWithPresigned(file, undefined, undefined, ASSET_TYPE.BANNER_ARTWORK)
+        if (!isMountedRef.current) return
+        setForm((prev) => ({ ...prev, asset_id: asset.id, previewUrl: asset.assets_url }))
+        showToast('Image uploaded', 'success')
+      } catch (err) {
+        console.error('Asset upload failed', err)
+        if (isMountedRef.current) showToast('Failed to upload image', 'error')
+      } finally {
+        if (isMountedRef.current) setIsUploading(false)
+      }
+    }
+    input.click()
+  }
+
+  const handleCreate = async () => {
+    if (!form.name.trim()) {
+      showToast('Name is required', 'error')
+      return
+    }
+    if (!form.asset_id) {
+      showToast('Image is required', 'error')
+      return
+    }
+
+    setIsSaving(true)
+    try {
+      await dispatch(
+        createProfileBanner({
+          name: form.name.trim(),
+          asset_id: form.asset_id,
+          is_default: form.is_default,
+        }),
+      ).unwrap()
+      if (!isMountedRef.current) return
+      showToast('Profile banner created', 'success')
+      setIsCreateOpen(false)
+      dispatch(fetchProfileBanners())
+    } catch (err) {
+      const message = typeof err === 'string' ? err : 'Failed to create profile banner'
+      if (isMountedRef.current) showToast(message, 'error')
+    } finally {
+      if (isMountedRef.current) setIsSaving(false)
+    }
+  }
+
+  return (
+    <Container justify="start">
+      <div className="w-full overflow-x-auto">
+        <div className="flex items-center justify-between mb-4">
+          <h1 className="text-2xl font-bold">Profile Banners</h1>
+          <Button variant="primary" onClick={openCreate}>
+            Add Profile Banner
+          </Button>
+        </div>
+
+        <DataTable
+          data={banners}
+          loading={loading}
+          error={error}
+          emptyMessage="No profile banners found."
+          columns={columns}
+        />
+      </div>
+
+      <Modal
+        title="Add Profile Banner"
+        isOpen={isCreateOpen}
+        onClose={() => setIsCreateOpen(false)}
+        footer={
+          <>
+            <Button variant="ghost" onClick={() => setIsCreateOpen(false)} disabled={isSaving}>
+              Cancel
+            </Button>
+            <Button variant="primary" onClick={handleCreate} disabled={isSaving || isUploading}>
+              {isSaving ? 'Saving...' : 'Save'}
+            </Button>
+          </>
+        }
+      >
+        <div className="flex flex-col gap-4">
+          <label className="form-control w-full">
+            <span className="label-text mb-1">Name</span>
+            <input
+              type="text"
+              className="input input-bordered w-full"
+              value={form.name}
+              onChange={(e) => setForm((prev) => ({ ...prev, name: e.target.value }))}
+              placeholder="Banner name"
+            />
+          </label>
+
+          <div className="form-control w-full">
+            <span className="label-text mb-1">Image</span>
+            <div className="flex items-center gap-3">
+              <Button variant="secondary" size="sm" onClick={handleFileUpload} disabled={isUploading}>
+                {isUploading ? 'Uploading...' : 'Upload Image'}
+              </Button>
+              {form.asset_id ? (
+                <span className="text-sm text-gray-500">asset #{form.asset_id}</span>
+              ) : null}
+            </div>
+            {form.previewUrl ? (
+              <img src={form.previewUrl} alt="Preview" className="mt-3 h-24 w-44 object-cover rounded" />
+            ) : null}
+          </div>
+
+          <label className="label cursor-pointer justify-start gap-3">
+            <input
+              type="checkbox"
+              className="checkbox"
+              checked={form.is_default}
+              onChange={(e) => setForm((prev) => ({ ...prev, is_default: e.target.checked }))}
+            />
+            <span className="label-text">Set as default</span>
+          </label>
+        </div>
+      </Modal>
+
+      <ToastContainer />
+    </Container>
+  )
+}
+
+export default ProfileBanner

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -1,0 +1,14 @@
+import { Route, Routes } from 'react-router-dom'
+import { routeConfig } from './routeConfig'
+
+function AppRoutes() {
+  return (
+    <Routes>
+      {routeConfig.map(({ path, component: Component }) => (
+        <Route key={path} path={path} element={<Component />} />
+      ))}
+    </Routes>
+  )
+}
+
+export default AppRoutes

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -1,0 +1,44 @@
+// Single source of truth for the dashboard route paths so the `/dashboard`
+// base isn't repeated on every route. Build child paths from DASHBOARD.
+const DASHBOARD = '/dashboard'
+
+// `p('')` -> '/dashboard', `p('cards')` -> '/dashboard/cards'.
+const p = (segment: string) => (segment ? `${DASHBOARD}/${segment}` : `${DASHBOARD}/`)
+
+export const ROUTES = {
+  home: p(''),
+  cards: p('cards'),
+  cardVariant: p('cards/variant'),
+  gachaPack: p('cards/gacha-pack'),
+  gachaPackDetails: p('cards/gacha-pack/:id'),
+  songs: p('songs'),
+  quotes: p('quotes'),
+  users: p('users'),
+  items: p('items'),
+  shopHistory: p('shop-history'),
+  transactionLog: p('transaction-log'),
+  forgotPassword: p('forgot-password'),
+  verify: p('verify'),
+  resendVerify: p('resend-verify'),
+  role: p('role'),
+  permissions: p('permissions'),
+  element: p('element'),
+  gameItems: p('game-items'),
+  gameItemsType: p('game-items-type'),
+  assets: p('assets'),
+  news: p('news'),
+  newsDetail: p('news/:id'),
+  newsType: p('news-type'),
+  member: p('member'),
+  rarity: p('rarity'),
+  currency: p('currency'),
+  beatmapEditor: p('beatmap-editor'),
+  beatmapEditorForSong: p(':song_id/beatmap-editor'),
+  events: p('events'),
+  eventDetail: p('events/:id'),
+  bannerTypes: p('banner-types'),
+  banners: p('banners'),
+  profileBanner: p('profile-banner'),
+} as const
+
+export type RouteKey = keyof typeof ROUTES

--- a/src/routes/routeConfig.ts
+++ b/src/routes/routeConfig.ts
@@ -1,0 +1,78 @@
+import { lazy, type ComponentType } from 'react'
+import Home from '../pages/Home'
+import Card from '../pages/Card'
+import Song from '../pages/Song'
+import Quote from '../pages/Quote'
+import User from '../pages/User'
+import Item from '../pages/Item'
+import Role from '../pages/Role'
+import ShopTransactions from '../pages/ShopTransactions'
+import TransactionLog from '../pages/TransactionLog'
+import ForgotPassword from '../pages/ForgotPassword'
+import VerifyUser from '../pages/VerifyUser'
+import ResendVerification from '../pages/ResendVerification'
+import Permission from '../pages/Permissions'
+import GameItemsType from '../pages/GameItemsType'
+import GameItems from '../pages/GameItems'
+import Element from '../pages/Element'
+import Assets from '../pages/Assets'
+import News from '../pages/News'
+import NewsDetail from '../pages/NewsDetail'
+import NewsType from '../pages/NewsType'
+import CardVariant from '../pages/CardVariant'
+import GachaPack from '../pages/GachaPack'
+import GachaPackDetails from '../pages/GachaPackDetails'
+import Member from '../pages/Member'
+import Rarity from '../pages/Rarity'
+import Currency from '../pages/Currency'
+import BeatmapEditor from '../pages/BeatmapEditor'
+import { ROUTES } from './paths'
+
+// Lazy-loaded pages
+const Events = lazy(() => import('../pages/Events'))
+const EventDetail = lazy(() => import('../pages/EventDetail'))
+const BannerType = lazy(() => import('../pages/BannerType'))
+const Banner = lazy(() => import('../pages/Banner'))
+const ProfileBanner = lazy(() => import('../pages/ProfileBanner'))
+
+export type RouteEntry = {
+  path: string
+  component: ComponentType
+}
+
+// Single list of path -> page. Add a route by appending one entry here.
+export const routeConfig: RouteEntry[] = [
+  { path: ROUTES.home, component: Home },
+  { path: ROUTES.cards, component: Card },
+  { path: ROUTES.cardVariant, component: CardVariant },
+  { path: ROUTES.gachaPack, component: GachaPack },
+  { path: ROUTES.gachaPackDetails, component: GachaPackDetails },
+  { path: ROUTES.songs, component: Song },
+  { path: ROUTES.quotes, component: Quote },
+  { path: ROUTES.users, component: User },
+  { path: ROUTES.items, component: Item },
+  { path: ROUTES.shopHistory, component: ShopTransactions },
+  { path: ROUTES.transactionLog, component: TransactionLog },
+  { path: ROUTES.forgotPassword, component: ForgotPassword },
+  { path: ROUTES.verify, component: VerifyUser },
+  { path: ROUTES.resendVerify, component: ResendVerification },
+  { path: ROUTES.role, component: Role },
+  { path: ROUTES.permissions, component: Permission },
+  { path: ROUTES.element, component: Element },
+  { path: ROUTES.gameItems, component: GameItems },
+  { path: ROUTES.gameItemsType, component: GameItemsType },
+  { path: ROUTES.assets, component: Assets },
+  { path: ROUTES.news, component: News },
+  { path: ROUTES.newsDetail, component: NewsDetail },
+  { path: ROUTES.newsType, component: NewsType },
+  { path: ROUTES.member, component: Member },
+  { path: ROUTES.rarity, component: Rarity },
+  { path: ROUTES.currency, component: Currency },
+  { path: ROUTES.beatmapEditor, component: BeatmapEditor },
+  { path: ROUTES.beatmapEditorForSong, component: BeatmapEditor },
+  { path: ROUTES.events, component: Events },
+  { path: ROUTES.eventDetail, component: EventDetail },
+  { path: ROUTES.bannerTypes, component: BannerType },
+  { path: ROUTES.banners, component: Banner },
+  { path: ROUTES.profileBanner, component: ProfileBanner }
+]

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -24,6 +24,7 @@ import assetTypesReducer from '../features/assetTypes/assetTypeSlice'
 import eventsReducer from '../features/events/eventSlice'
 import bannerTypesReducer from '../features/bannerTypes/bannerTypeSlice'
 import bannersReducer from '../features/banners/bannerSlice'
+import profileBannersReducer from '../features/profileBanner/profileBannerSlice'
 
 
 export const store = configureStore({
@@ -53,6 +54,7 @@ export const store = configureStore({
         events: eventsReducer,
         bannerTypes: bannerTypesReducer,
         banners: bannersReducer,
+        profileBanners: profileBannersReducer,
     }
 })
 


### PR DESCRIPTION
- Add ProfileBanner page with DataTable list and create modal (image upload via presigned URL + name + is_default)
- Add profileBanner slice (fetch/create thunks) and register in store
- Add profileBanner Zod schemas (list envelope + create payload)
- Add shared ASSET_TYPE constants mirrored from backend; use BANNER_ARTWORK for profile banner uploads and replace magic numbers in songSlice (BEATMAP) and gameItemsSlice (ARTWORK)
- Extract router into src/routes (AppRoutes, routeConfig, paths) driven by a data-mapped route list; slim down App.tsx
- Add Container `justify` prop to allow left-aligned content
- Add Profile Banners sidebar entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Profile Banners page to view and add profile banners.
  * Added a new sidebar item for Profile Banners.
  * Added configurable horizontal alignment (left/center/right) to containers.
* **Bug Fixes**
  * Improved asset uploads by using consistent asset-type identifiers across uploads (including artwork and beatmaps).
* **Refactor**
  * Streamlined routing by centralizing route definitions and delegating navigation to a dedicated routes component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->