### PR TITLE
feat(bundle): asset bundle build page + restore admin mail route

### DIFF
--- a/src/components/sidebarConfig.tsx
+++ b/src/components/sidebarConfig.tsx
@@ -71,6 +71,11 @@ export const Icons = {
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
     </svg>
   ),
+  Bundle: (
+    <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />
+    </svg>
+  ),
 }
 
 export const sidebarMenu: MenuItem[] = [
@@ -136,6 +141,14 @@ export const sidebarMenu: MenuItem[] = [
     icon: Icons.Inbox,
     children: [
       { key: 'inbox-send', label: 'Send Mail', path: '/dashboard/inbox/send', icon: Icons.Inbox, permission: 'inbox.send' },
+    ],
+  },
+  {
+    key: 'build',
+    label: 'Build',
+    icon: Icons.Bundle,
+    children: [
+      { key: 'bundle', label: 'Asset Bundle', path: '/dashboard/bundle', icon: Icons.Bundle, permission: 'bundle.trigger' },
     ],
   },
 ]

--- a/src/features/bundle/bundleSlice.ts
+++ b/src/features/bundle/bundleSlice.ts
@@ -1,0 +1,107 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import axios from 'axios';
+import { API_BASE_URL } from '../../helpers/constants';
+import { getAuthHeader } from '../../helpers/getAuthHeader';
+import { handleThunkError } from '../../helpers/handleThunkError';
+import { validateOrReject } from '../../helpers/validateApi';
+import {
+    BundleStatusSchema,
+    BundleTriggerResponseSchema,
+    type BundleStatus,
+    type BundleTriggerResponse,
+} from '../../lib/schemas/bundle';
+
+type BundleState = {
+    status: BundleStatus | null;
+    loading: boolean;
+    triggering: boolean;
+    error: string | null;
+    lastTriggeredAt: string | null;
+};
+
+const initialState: BundleState = {
+    status: null,
+    loading: false,
+    triggering: false,
+    error: null,
+    lastTriggeredAt: null,
+};
+
+export const fetchBundleStatus = createAsyncThunk<
+    BundleStatus,
+    void,
+    { rejectValue: string }
+>(
+    'bundle/fetchStatus',
+    async (_, thunkAPI) => {
+        try {
+            const response = await axios.get(
+                `${API_BASE_URL}/bundle/status`,
+                { headers: getAuthHeader() },
+            );
+            return validateOrReject(BundleStatusSchema, response.data, thunkAPI) as BundleStatus;
+        } catch (error) {
+            return handleThunkError(error, thunkAPI);
+        }
+    },
+);
+
+export const triggerBundleBuild = createAsyncThunk<
+    BundleTriggerResponse,
+    void,
+    { rejectValue: string }
+>(
+    'bundle/trigger',
+    async (_, thunkAPI) => {
+        try {
+            const response = await axios.post(
+                `${API_BASE_URL}/bundle/trigger`,
+                {},
+                { headers: getAuthHeader() },
+            );
+            return validateOrReject(BundleTriggerResponseSchema, response.data, thunkAPI) as BundleTriggerResponse;
+        } catch (error) {
+            return handleThunkError(error, thunkAPI);
+        }
+    },
+);
+
+const bundleSlice = createSlice({
+    name: 'bundle',
+    initialState,
+    reducers: {
+        resetBundleError(state) {
+            state.error = null;
+        },
+    },
+    extraReducers(builder) {
+        builder
+            .addCase(fetchBundleStatus.pending, (state) => {
+                state.loading = true;
+                state.error = null;
+            })
+            .addCase(fetchBundleStatus.fulfilled, (state, action) => {
+                state.loading = false;
+                state.status = action.payload;
+            })
+            .addCase(fetchBundleStatus.rejected, (state, action) => {
+                state.loading = false;
+                state.error = action.payload ?? action.error.message ?? 'Failed to load bundle status';
+            })
+            .addCase(triggerBundleBuild.pending, (state) => {
+                state.triggering = true;
+                state.error = null;
+            })
+            .addCase(triggerBundleBuild.fulfilled, (state) => {
+                state.triggering = false;
+                state.lastTriggeredAt = new Date().toISOString();
+            })
+            .addCase(triggerBundleBuild.rejected, (state, action) => {
+                state.triggering = false;
+                state.error = action.payload ?? action.error.message ?? 'Failed to trigger bundle build';
+            });
+    },
+});
+
+export const { resetBundleError } = bundleSlice.actions;
+export default bundleSlice.reducer;

--- a/src/lib/schemas/bundle.ts
+++ b/src/lib/schemas/bundle.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+export const BundleStatusSchema = z.object({
+    is_dirty: z.boolean(),
+    in_progress: z.boolean(),
+    bundle_version: z.number().int().nonnegative(),
+    manifest_md5: z.string().nullable(),
+    archive_url: z.string().url().nullable(),
+    last_built_at: z.string().nullable(),
+    last_edit_at: z.string().nullable(),
+});
+
+export const BundleTriggerResponseSchema = z.object({
+    message: z.string(),
+    status: z.string(),
+});
+
+export type BundleStatus = z.infer<typeof BundleStatusSchema>;
+export type BundleTriggerResponse = z.infer<typeof BundleTriggerResponseSchema>;

--- a/src/pages/Bundle.tsx
+++ b/src/pages/Bundle.tsx
@@ -1,0 +1,172 @@
+import { useEffect, useRef } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import moment from 'moment';
+import Container from '../components/Container';
+import {
+    fetchBundleStatus,
+    triggerBundleBuild,
+    resetBundleError,
+} from '../features/bundle/bundleSlice';
+import type { RootState, AppDispatch } from '../store';
+import { useToast } from '../hooks/useToast';
+import { useHasPermission } from '../hooks/usePermissions';
+
+const POLL_INTERVAL_MS = 3000;
+
+function formatDate(value: string | null): string {
+    if (!value) return '—';
+    const parsed = moment(value);
+    return parsed.isValid() ? parsed.format('DD MMM YYYY, HH:mm') : value;
+}
+
+export function Bundle() {
+    const dispatch = useDispatch<AppDispatch>();
+    const { status, loading, triggering, error } = useSelector((state: RootState) => state.bundle);
+    const { showToast, ToastContainer } = useToast();
+    const canTrigger = useHasPermission('bundle.trigger');
+
+    const inProgress = status?.in_progress ?? false;
+    const wasInProgress = useRef(false);
+
+    useEffect(() => {
+        dispatch(fetchBundleStatus());
+    }, [dispatch]);
+
+    // Poll while a build is in progress; stop once it settles.
+    useEffect(() => {
+        if (!inProgress) return;
+        const id = window.setInterval(() => {
+            dispatch(fetchBundleStatus());
+        }, POLL_INTERVAL_MS);
+        return () => window.clearInterval(id);
+    }, [inProgress, dispatch]);
+
+    // Toast when a build finishes (in_progress goes true -> false).
+    useEffect(() => {
+        if (wasInProgress.current && !inProgress && status) {
+            showToast('Bundle build finished.', 'success');
+        }
+        wasInProgress.current = inProgress;
+    }, [inProgress, status, showToast]);
+
+    useEffect(() => {
+        if (error) {
+            showToast(error, 'error');
+            dispatch(resetBundleError());
+        }
+    }, [error, showToast, dispatch]);
+
+    const handleTrigger = async () => {
+        const result = await dispatch(triggerBundleBuild());
+        if (triggerBundleBuild.fulfilled.match(result)) {
+            showToast(result.payload.message ?? 'Bundle build started', 'success');
+            dispatch(fetchBundleStatus());
+        }
+    };
+
+    if (!canTrigger) {
+        return (
+            <Container>
+                <div className="alert alert-error w-full max-w-xl">
+                    <span>You do not have permission to manage the asset bundle.</span>
+                </div>
+            </Container>
+        );
+    }
+
+    const isDirty = status?.is_dirty ?? false;
+    const triggerDisabled = triggering || inProgress || loading;
+
+    return (
+        <Container className="flex-col items-center">
+            <ToastContainer />
+            <div className="w-full max-w-2xl">
+                <h1 className="text-2xl font-semibold mb-1">Asset Bundle</h1>
+
+                <div className="card bg-base-100 shadow p-6 flex flex-col gap-5">
+                    <div className="flex items-center gap-2 flex-wrap">
+                        {inProgress ? (
+                            <span className="badge badge-info gap-2">
+                                <span className="loading loading-spinner loading-xs" />
+                                Build in progress
+                            </span>
+                        ) : isDirty ? (
+                            <span className="badge badge-warning">Changes pending — rebuild needed</span>
+                        ) : (
+                            <span className="badge badge-success">Up to date</span>
+                        )}
+                        {loading && !inProgress && (
+                            <span className="text-sm text-base-content/50">Refreshing…</span>
+                        )}
+                    </div>
+
+                    <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-3 text-sm">
+                        <div>
+                            <dt className="text-base-content/50">Bundle version</dt>
+                            <dd className="font-medium">{status?.bundle_version ?? '—'}</dd>
+                        </div>
+                        <div>
+                            <dt className="text-base-content/50">Manifest MD5</dt>
+                            <dd className="font-mono text-xs break-all">{status?.manifest_md5 ?? '—'}</dd>
+                        </div>
+                        <div>
+                            <dt className="text-base-content/50">Last built</dt>
+                            <dd className="font-medium">{formatDate(status?.last_built_at ?? null)}</dd>
+                        </div>
+                        <div>
+                            <dt className="text-base-content/50">Last edit</dt>
+                            <dd className="font-medium">{formatDate(status?.last_edit_at ?? null)}</dd>
+                        </div>
+                        <div className="sm:col-span-2">
+                            <dt className="text-base-content/50">Archive</dt>
+                            <dd>
+                                {status?.archive_url ? (
+                                    <a
+                                        href={status.archive_url}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="link link-primary break-all text-xs"
+                                    >
+                                        {status.archive_url}
+                                    </a>
+                                ) : (
+                                    '—'
+                                )}
+                            </dd>
+                        </div>
+                    </dl>
+
+                    <div className="flex gap-3">
+                        <button
+                            type="button"
+                            className="btn btn-primary"
+                            onClick={handleTrigger}
+                            disabled={triggerDisabled}
+                        >
+                            {triggering ? (
+                                <>
+                                    <span className="loading loading-spinner loading-sm" />
+                                    Starting…
+                                </>
+                            ) : inProgress ? (
+                                'Build running…'
+                            ) : (
+                                'Trigger build'
+                            )}
+                        </button>
+                        <button
+                            type="button"
+                            className="btn btn-ghost"
+                            onClick={() => dispatch(fetchBundleStatus())}
+                            disabled={loading}
+                        >
+                            Refresh
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </Container>
+    );
+}
+
+export default Bundle;

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -39,6 +39,8 @@ export const ROUTES = {
   bannerTypes: p('banner-types'),
   banners: p('banners'),
   profileBanner: p('profile-banner'),
+  adminMail: p('inbox/send'),
+  bundle: p('bundle'),
 } as const
 
 export type RouteKey = keyof typeof ROUTES

--- a/src/routes/routeConfig.ts
+++ b/src/routes/routeConfig.ts
@@ -34,6 +34,8 @@ const EventDetail = lazy(() => import('../pages/EventDetail'))
 const BannerType = lazy(() => import('../pages/BannerType'))
 const Banner = lazy(() => import('../pages/Banner'))
 const ProfileBanner = lazy(() => import('../pages/ProfileBanner'))
+const AdminMail = lazy(() => import('../pages/AdminMail'))
+const Bundle = lazy(() => import('../pages/Bundle'))
 
 export type RouteEntry = {
   path: string
@@ -74,5 +76,7 @@ export const routeConfig: RouteEntry[] = [
   { path: ROUTES.eventDetail, component: EventDetail },
   { path: ROUTES.bannerTypes, component: BannerType },
   { path: ROUTES.banners, component: Banner },
-  { path: ROUTES.profileBanner, component: ProfileBanner }
+  { path: ROUTES.profileBanner, component: ProfileBanner },
+  { path: ROUTES.adminMail, component: AdminMail },
+  { path: ROUTES.bundle, component: Bundle }
 ]

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -26,6 +26,7 @@ import bannerTypesReducer from '../features/bannerTypes/bannerTypeSlice'
 import bannersReducer from '../features/banners/bannerSlice'
 import profileBannersReducer from '../features/profileBanner/profileBannerSlice'
 import inboxReducer from '../features/inbox/inboxSlice';
+import bundleReducer from '../features/bundle/bundleSlice';
 
 
 export const store = configureStore({
@@ -57,6 +58,7 @@ export const store = configureStore({
         banners: bannersReducer,
         profileBanners: profileBannersReducer,
         inbox: inboxReducer,
+        bundle: bundleReducer,
     }
 })
 


### PR DESCRIPTION
## Summary

- Adds an **Asset Bundle** admin page to trigger the backend bundle build so Unity can consume the latest assets. Shows current status (version, manifest MD5, last built/edit, archive link) and a **Trigger build** action.
- After triggering, the page **auto-polls** `/bundle/status` every 3s while `in_progress` is true, then stops and toasts on completion.
- Gated on the `bundle.trigger` permission (page + sidebar entry).
- Restores the **AdminMail (`/dashboard/inbox/send`) route** that was missing from `routeConfig`, so the existing sidebar "Send Mail" link now resolves.

## Changes

- `src/lib/schemas/bundle.ts` — Zod schemas for `/bundle/status` and `/bundle/trigger` responses.
- `src/features/bundle/bundleSlice.ts` — `fetchBundleStatus` + `triggerBundleBuild` thunks and slice.
- `src/pages/Bundle.tsx` — the page UI (dates formatted with moment, e.g. `03 Jul 2026, 15:19`).
- `src/store/index.ts` — registered `bundle` reducer.
- `src/routes/paths.ts`, `src/routes/routeConfig.ts` — added `bundle` and `adminMail` routes (both lazy-loaded).
- `src/components/sidebarConfig.tsx` — new "Build → Asset Bundle" nav entry.

## Test plan

- [ ] Backend exposes `bundle.trigger` permission; verify page/sidebar gating for users with and without it.
- [ ] Load `/dashboard/bundle` → status renders; dates readable; archive link opens.
- [ ] Click **Trigger build** → toast, badge switches to "Build in progress", status auto-polls, then "Up to date" + completion toast.
- [ ] Click sidebar **Send Mail** → `/dashboard/inbox/send` now loads the AdminMail form.
- [ ] `npx tsc --noEmit` passes (verified locally).

> Note: no unit tests added yet for the slice/poll effect — can follow up if required before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)